### PR TITLE
Setup Default DB and created register and login endpoints with tests

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -1,0 +1,34 @@
+package db
+
+import (
+	"os"
+	"fmt"
+	"gorm.io/gorm"
+	"log"
+	"gorm.io/driver/postgres"
+)
+
+var DB *gorm.DB
+
+func ConnectDB() {
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		dsn = "host=localhost user=postgres password=yourpassword dbname=dialecto port=5432 sslmode=disable"
+	}
+
+	var err error
+	DB, err = gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		log.Fatal("Failed to connect to database:", err)
+	}
+
+	sqlDB, err := DB.DB()
+	if err != nil {
+		log.Fatal("Failed to get DB instance:", err)
+	}
+	if err = sqlDB.Ping(); err != nil {
+		log.Fatal("Database ping failed:", err)
+	}
+
+	fmt.Println("Connected to PostgreSQL!")
+}

--- a/handlers/auth.go
+++ b/handlers/auth.go
@@ -1,0 +1,76 @@
+package handlers
+
+import (
+	"Dialecto-API/db"
+	"Dialecto-API/models"
+	"net/http"
+	"os"
+	"time"
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
+	"golang.org/x/crypto/bcrypt"
+)
+
+var jwtKey []byte
+
+func init() {
+	jwtKey = []byte(os.Getenv("JWT_SECRET"))
+	if len(jwtKey) == 0 {
+		jwtKey = []byte("default-secret-key")
+	}
+}
+
+func RegisterUser(c *gin.Context) {
+	var user models.User
+	// Decode JSON request into user struct.
+	if err := c.ShouldBindJSON(&user); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request payload"})
+		return
+	}
+
+	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(user.Password), bcrypt.DefaultCost)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error hashing password"})
+		return
+	}
+	user.Password = string(hashedPassword)
+
+	if err := db.DB.Create(&user).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error saving user"})
+		return
+	}
+
+	c.JSON(http.StatusCreated, gin.H{"message": "User registered successfully!"})
+}
+
+func LoginUser(c *gin.Context) {
+	var userInput models.User
+	if err := c.ShouldBindJSON(&userInput); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request"})
+		return
+	}
+
+	var storedUser models.User
+	if err := db.DB.Where("email = ?", userInput.Email).First(&storedUser).Error; err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid credentials"})
+		return
+	}
+
+	if err := bcrypt.CompareHashAndPassword([]byte(storedUser.Password), []byte(userInput.Password)); err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid credentials"})
+		return
+	}
+
+	claims := jwt.MapClaims{
+		"user_id": storedUser.ID,
+		"exp":     time.Now().Add(24 * time.Hour).Unix(),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenString, err := token.SignedString(jwtKey)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Could not generate token"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"token": tokenString})
+}

--- a/handlers/auth_test.go
+++ b/handlers/auth_test.go
@@ -1,0 +1,111 @@
+package handlers
+
+import (
+	"bytes"
+	"Dialecto-API/db"
+	"Dialecto-API/models"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func setupRouter() *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	router := gin.Default()
+	router.POST("/register", RegisterUser)
+	router.POST("/login", LoginUser)
+	return router
+}
+
+
+func TestRegisterUser(t *testing.T) {
+	os.Setenv("DATABASE_URL", "host=localhost user=postgres password=yourpassword dbname=dialecto port=5432 sslmode=disable")
+	db.ConnectDB()
+	if err := db.DB.AutoMigrate(&models.User{}); err != nil {
+		t.Fatalf("Migration failed: %v", err)
+	}
+
+	router := setupRouter()
+
+	regData := map[string]string{
+		"email":    "testregister@example.com",
+		"password": "password123",
+	}
+	regBody, err := json.Marshal(regData)
+	if err != nil {
+		t.Fatalf("Failed to marshal registration data: %v", err)
+	}
+
+	req, err := http.NewRequest("POST", "/register", bytes.NewBuffer(regBody))
+	if err != nil {
+		t.Fatalf("Failed to create registration request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("Expected status %d but got %d", http.StatusCreated, w.Code)
+	}
+}
+
+func TestLoginUser(t *testing.T) {
+	os.Setenv("DATABASE_URL", "host=localhost user=postgres password=yourpassword dbname=dialecto port=5432 sslmode=disable")
+	db.ConnectDB()
+	
+	if err := db.DB.AutoMigrate(&models.User{}); err != nil {
+		t.Fatalf("Migration failed: %v", err)
+	}
+
+	router := setupRouter()
+
+	regData := map[string]string{
+		"email":    "testlogin@example.com",
+		"password": "password123",
+	}
+	regBody, err := json.Marshal(regData)
+	if err != nil {
+		t.Fatalf("Failed to marshal registration data: %v", err)
+	}
+	req, err := http.NewRequest("POST", "/register", bytes.NewBuffer(regBody))
+	if err != nil {
+		t.Fatalf("Failed to create registration request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	loginBody, err := json.Marshal(regData)
+	if err != nil {
+		t.Fatalf("Failed to marshal login data: %v", err)
+	}
+	req, err = http.NewRequest("POST", "/login", bytes.NewBuffer(loginBody))
+	if err != nil {
+		t.Fatalf("Failed to create login request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status %d but got %d", http.StatusOK, w.Code)
+	}
+
+	var response map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("Failed to unmarshal login response: %v", err)
+	}
+
+	token, exists := response["token"]
+	if !exists {
+		t.Error("Expected token in response, but it was missing")
+	}
+	if token == "" {
+		t.Error("Expected non-empty token, but got an empty string")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"Dialecto-API/db"
+	"Dialecto-API/handlers"
+	"Dialecto-API/models"
+	"log"
+	"net/http"
+	"github.com/gin-gonic/gin"
+)
+
+func main() {
+	db.ConnectDB()
+
+	if err := db.DB.AutoMigrate(&models.User{}); err != nil {
+		log.Fatal("Migration Failed:", err)
+	}
+	log.Println("Database migration complete!")
+
+	gin.SetMode(gin.DebugMode)
+	router := gin.Default()
+
+	router.POST("/register", handlers.RegisterUser)
+	router.POST("/login", handlers.LoginUser)
+	router.GET("/health", func(c *gin.Context) {
+		c.String(http.StatusOK, "OK")
+	})
+
+	log.Println("Server running on port 8080")
+	if err := router.Run(":8080"); err != nil {
+		log.Fatal("Failed to run server:", err)
+	}
+}

--- a/models/user.go
+++ b/models/user.go
@@ -1,0 +1,9 @@
+package models
+
+import "gorm.io/gorm"
+
+type User struct {
+	gorm.Model	
+	Email	string `gorm:"unique;not null"`
+	Password string `gorm:"not null"`
+}


### PR DESCRIPTION
This PR implements user authentication for Dialecto’s Go backend. Key additions include:

Database Connection & Model:

- Added db/db.go to establish a PostgreSQL connection using GORM.
- Created a User model in models/user.go with fields for email and a bcrypt-hashed password.

Authentication Handlers:

- Implemented registration (/register) and login (/login) endpoints in handlers/auth.go using Gin.
- Registration hashes passwords with bcrypt and stores users via GORM.
- Login verifies credentials and issues a JWT token signed with a secret key.

Testing:

- Added separate tests for registration and login in handlers/auth_test.go using Go’s standard testing package.

Routing & Server Setup:

- Updated main.go to auto-migrate the User model and expose health-check, register, and login endpoints.